### PR TITLE
Fix issue where falsey settings in the config file are ignored

### DIFF
--- a/lib/conker.rb
+++ b/lib/conker.rb
@@ -198,7 +198,7 @@ module Conker
 
     private
     def check_missing_value!(varname)
-      if required_in_environments.member?(@environment.to_sym) && !@config[varname]
+      if required_in_environments.member?(@environment.to_sym) && @config[varname].nil?
         raise MustBeDefined
       end
     end

--- a/lib/conker.rb
+++ b/lib/conker.rb
@@ -213,7 +213,7 @@ module Conker
     end
 
     def from_config_variable_or_default(varname)
-      if @config[varname] && @environment != 'test'
+      if !@config[varname].nil? && @environment != 'test'
         interpret_value(@config[varname], @declaration_opts[:type])
       else
         default_value
@@ -239,7 +239,11 @@ module Conker
       type = type.to_sym if type
       case type
       when :boolean
-        value.to_s.downcase == "true" || value.to_i == 1
+        if [true, false].include? value
+          value
+        else
+          value.to_s.downcase == "true" || value.to_i == 1
+        end
         # defaults to false if omitted
       when :integer
         Integer(value)

--- a/spec/lib/conker_spec.rb
+++ b/spec/lib/conker_spec.rb
@@ -176,10 +176,10 @@ describe Conker do
 
     describe 'typed variables' do
       describe 'boolean' do
-        def setup_sprocket_enabled!(value_string)
+        def setup_sprocket_enabled!(value_string, default = false)
           Conker.module_eval do
             setup_config! :development, {'SPROCKET_ENABLED' => value_string},
-                          SPROCKET_ENABLED: optional(type: :boolean, default: false)
+                          SPROCKET_ENABLED: optional(type: :boolean, default: default)
           end
         end
 
@@ -200,6 +200,11 @@ describe Conker do
 
         it 'accepts "0" as false' do
           setup_sprocket_enabled! '0'
+          SPROCKET_ENABLED.should be_false
+        end
+
+        it 'handles a falsey value properly' do
+          setup_sprocket_enabled! false, true
           SPROCKET_ENABLED.should be_false
         end
       end


### PR DESCRIPTION
When the config file is read here:

https://github.com/rapportive/conker/blob/master/lib/conker.rb#L146

The settings are evaluated, so if you have something like this:

``` ruby
MY_COOL_SETTING: false
```

The `false` value becomes a `FalseClass` rather than a `String`. This causes the test for truthiness to believe that we haven't set the value at all.

Example scenario:

In constants.rb the constant is configured thus:

``` ruby
:MY_COOL_SETTING => optional(:type => :boolean, :default => true)
```

and the constants.yml file contans:

``` ruby
MY_COOL_SETTING: false
```

The resulting value of `MY_COOL_SETTING` is `true`, which is unexpected.
